### PR TITLE
Release v1.10.0: Improve Ona setup by removing LINEAR_API_KEY requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The `setup` command automates the installation and configuration process for var
 
 ```bash
 # Set your Linear API key as an environment variable
+# Only exception: Ona does not require this for setup!
 export LINEAR_API_KEY=your_linear_api_key
 
 # Set up for Cline (default)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -27,13 +27,21 @@ Currently supported tools: cline, roo-code, claude-code, ona`,
 		autoApprove, _ := cmd.Flags().GetString("auto-approve")
 		projectPath, _ := cmd.Flags().GetString("project-path")
 
-		// Check if the Linear API key is provided in the environment
+		// Check if the Linear API key is provided in the environment (for tools that need it)
 		apiKey := os.Getenv("LINEAR_API_KEY")
-		if apiKey == "" {
-			fmt.Println("Error: LINEAR_API_KEY environment variable is required")
-			fmt.Println("Please set it before running the setup command:")
-			fmt.Println("export LINEAR_API_KEY=your_linear_api_key")
-			os.Exit(1)
+		tools := strings.Split(toolParam, ",")
+		for _, t := range tools {
+			doesNotNeedApiKey := strings.TrimSpace(t) == "ona"
+			if doesNotNeedApiKey {
+				continue
+			}
+
+			if apiKey == "" {
+				fmt.Println("Error: LINEAR_API_KEY environment variable is required")
+				fmt.Println("Please set it before running the setup command:")
+				fmt.Println("export LINEAR_API_KEY=your_linear_api_key")
+				os.Exit(1)
+			}
 		}
 
 		// Create the MCP servers directory if it doesn't exist
@@ -61,9 +69,7 @@ Currently supported tools: cline, roo-code, claude-code, ona`,
 		}
 
 		// Process each tool
-		tools := strings.Split(toolParam, ",")
 		hasErrors := false
-
 		for _, t := range tools {
 			t = strings.TrimSpace(t)
 			if t == "" {
@@ -242,12 +248,8 @@ func setupOna(binaryPath, apiKey string, writeAccess bool, autoApprove, projectP
 		"args":    serverArgs,
 	}
 
-	// Add environment variables
-	if apiKey != "" {
-		linearServerConfig["env"] = map[string]string{
-			"LINEAR_API_KEY": apiKey,
-		}
-	}
+	// Ona will automatically provide LINEAR_API_KEY from environment
+	// No need to explicitly set it in the configuration
 
 	// Read existing configuration or create new one
 	var config map[string]interface{}

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -1007,10 +1007,7 @@ func TestSetupCommand(t *testing.T) {
 								"linear": {
 									"name": "linear",
 									"command": "home/mcp-servers/linear-mcp-go",
-									"args": ["serve", "--write-access=true"],
-									"env": {
-										"LINEAR_API_KEY": "test-api-key"
-									}
+									"args": ["serve", "--write-access=true"]
 								}
 							}
 						}`,
@@ -1034,10 +1031,7 @@ func TestSetupCommand(t *testing.T) {
 								"linear": {
 									"name": "linear",
 									"command": "home/mcp-servers/linear-mcp-go",
-									"args": ["serve", "--write-access=false"],
-									"env": {
-										"LINEAR_API_KEY": "test-api-key"
-									}
+									"args": ["serve", "--write-access=false"]
 								}
 							}
 						}`,
@@ -1079,10 +1073,7 @@ func TestSetupCommand(t *testing.T) {
 								"linear": {
 									"name": "linear",
 									"command": "home/mcp-servers/linear-mcp-go",
-									"args": ["serve", "--write-access=true"],
-									"env": {
-										"LINEAR_API_KEY": "test-api-key"
-									}
+									"args": ["serve", "--write-access=true"]
 								}
 							}
 						}`,
@@ -1273,10 +1264,7 @@ func TestSetupCommand(t *testing.T) {
 								"linear": {
 									"name": "linear",
 									"command": "home/mcp-servers/linear-mcp-go",
-									"args": ["serve", "--write-access=false"],
-									"env": {
-										"LINEAR_API_KEY": "test-api-key"
-									}
+									"args": ["serve", "--write-access=false"]
 								}
 							},
 							"globalSettings": {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -14,7 +14,7 @@ const (
 	// ServerName is the name of the MCP server
 	ServerName = "Linear MCP Server"
 	// ServerVersion is the version of the MCP server
-	ServerVersion = "1.9.0"
+	ServerVersion = "1.10.0"
 )
 
 // LinearMCPServer represents the Linear MCP server


### PR DESCRIPTION
## Release v1.10.0

### Changes

#### Improvements
- **Ona Integration**: The setup command for Ona no longer requires LINEAR_API_KEY to be explicitly configured in MCP settings. The MCP server now automatically reads the LINEAR_API_KEY from the environment, simplifying the setup process.

#### Technical Details
- Removed LINEAR_API_KEY from Ona MCP configuration generation
- Updated setup documentation to reflect automatic token reading
- Maintains backward compatibility with existing configurations
- Updated version to 1.10.0

This change makes the Ona setup process more streamlined while maintaining full functionality.

### Testing
- All tests pass
- Build successful
- Verified Ona setup works without explicit LINEAR_API_KEY configuration