### PR TITLE
[feature] Pick up LINEAR_WRITE_ACCESS at runtime

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/geropl/linear-mcp-go/pkg/server"
 	"github.com/spf13/cobra"
@@ -16,6 +17,20 @@ var serveCmd = &cobra.Command{
 The server provides tools for interacting with the Linear API through the MCP protocol.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		writeAccess, _ := cmd.Flags().GetBool("write-access")
+		writeAccessChanged := cmd.Flags().Changed("write-access")
+
+		// Check LINEAR_WRITE_ACCESS environment variable if flag wasn't explicitly set
+		if !writeAccessChanged {
+			if envWriteAccess := os.Getenv("LINEAR_WRITE_ACCESS"); envWriteAccess != "" {
+				envValue := strings.ToLower(strings.TrimSpace(envWriteAccess))
+				if envValue == "true" {
+					writeAccess = true
+				} else if envValue == "false" {
+					writeAccess = false
+				}
+				// If the env var is set to something other than "true" or "false", ignore it and use default
+			}
+		}
 
 		// Create the Linear MCP server
 		linearServer, err := server.NewLinearMCPServer(writeAccess)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -24,6 +24,7 @@ Currently supported tools: cline, roo-code, claude-code, ona`,
 	Run: func(cmd *cobra.Command, args []string) {
 		toolParam, _ := cmd.Flags().GetString("tool")
 		writeAccess, _ := cmd.Flags().GetBool("write-access")
+		writeAccessChanged := cmd.Flags().Changed("write-access")
 		autoApprove, _ := cmd.Flags().GetString("auto-approve")
 		projectPath, _ := cmd.Flags().GetString("project-path")
 
@@ -88,7 +89,7 @@ Currently supported tools: cline, roo-code, claude-code, ona`,
 			case "claude-code":
 				err = setupClaudeCode(binaryPath, apiKey, writeAccess, autoApprove, projectPath)
 			case "ona":
-				err = setupOna(binaryPath, apiKey, writeAccess, autoApprove, projectPath)
+				err = setupOna(binaryPath, apiKey, writeAccess, writeAccessChanged, autoApprove, projectPath)
 			default:
 				fmt.Printf("Unsupported tool: %s\n", t)
 				fmt.Println("Currently supported tools: cline, roo-code, claude-code, ona")
@@ -226,7 +227,7 @@ func getOnaConfigPath(projectPath string) (string, error) {
 }
 
 // setupOna sets up the Linear MCP server for Ona
-func setupOna(binaryPath, apiKey string, writeAccess bool, autoApprove, projectPath string) error {
+func setupOna(binaryPath, apiKey string, writeAccess bool, writeAccessChanged bool, autoApprove, projectPath string) error {
 	configPath, err := getOnaConfigPath(projectPath)
 	if err != nil {
 		return err
@@ -239,7 +240,10 @@ func setupOna(binaryPath, apiKey string, writeAccess bool, autoApprove, projectP
 
 	// Prepare server arguments
 	serverArgs := []string{"serve"}
-	serverArgs = append(serverArgs, fmt.Sprintf("--write-access=%t", writeAccess))
+	// Only add write-access argument if it was explicitly set
+	if writeAccessChanged {
+		serverArgs = append(serverArgs, fmt.Sprintf("--write-access=%t", writeAccess))
+	}
 
 	// Create the linear server configuration
 	linearServerConfig := map[string]interface{}{

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -1030,7 +1030,7 @@ func TestSetupCommand(t *testing.T) {
 							"mcpServers": {
 								"linear": {
 									"command": "home/mcp-servers/linear-mcp-go",
-									"args": ["serve", "--write-access=false"],
+									"args": ["serve"],
 									"disabled": false
 								}
 							}
@@ -1263,7 +1263,7 @@ func TestSetupCommand(t *testing.T) {
 								},
 								"linear": {
 									"command": "home/mcp-servers/linear-mcp-go",
-									"args": ["serve", "--write-access=false"],
+									"args": ["serve"],
 									"disabled": false
 								}
 							},

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -14,7 +14,7 @@ const (
 	// ServerName is the name of the MCP server
 	ServerName = "Linear MCP Server"
 	// ServerVersion is the version of the MCP server
-	ServerVersion = "1.11.0"
+	ServerVersion = "1.12.0"
 )
 
 // LinearMCPServer represents the Linear MCP server


### PR DESCRIPTION
Changes Made:

    Modified Ona setup command (cmd/setup.go):
        Dropped the default behavior of always adding --write-access=false
        Now only adds the --write-access argument when it's explicitly specified via the command line flag
        Updated function signature to track whether the flag was explicitly changed

    Enhanced serve command (cmd/serve.go):
        Added support for the LINEAR_WRITE_ACCESS environment variable
        The environment variable is only checked if the --write-access flag wasn't explicitly set
        Accepts "true" or "false" values (case-insensitive), ignoring invalid values

    Updated tests (cmd/setup_test.go):
        Modified test expectations to reflect the new behavior where --write-access=false is not added when not explicitly set
        All tests now pass

    Version bump:
        Updated version to v1.12.0 in pkg/server/server.go
