### PR TITLE
feat: add version command with build-time version information

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           check-latest: true
 
       - name: Build
-        run: go build -v ./...
+        run: go build -ldflags "-X github.com/geropl/linear-mcp-go/cmd.GitCommit=${{ github.sha }} -X github.com/geropl/linear-mcp-go/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" -v ./...
 
       - name: Test
         run: go test -v ./...
@@ -50,17 +50,17 @@ jobs:
 
       - name: Build for Linux
         run: |
-          GOOS=linux GOARCH=amd64 go build -o linear-mcp-go-linux-amd64 -v .
+          GOOS=linux GOARCH=amd64 go build -ldflags "-X github.com/geropl/linear-mcp-go/cmd.GitCommit=${{ github.sha }} -X github.com/geropl/linear-mcp-go/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o linear-mcp-go-linux-amd64 -v .
           chmod +x linear-mcp-go-linux-amd64
 
       - name: Build for macOS
         run: |
-          GOOS=darwin GOARCH=amd64 go build -o linear-mcp-go-darwin-amd64 -v .
+          GOOS=darwin GOARCH=amd64 go build -ldflags "-X github.com/geropl/linear-mcp-go/cmd.GitCommit=${{ github.sha }} -X github.com/geropl/linear-mcp-go/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o linear-mcp-go-darwin-amd64 -v .
           chmod +x linear-mcp-go-darwin-amd64
 
       - name: Build for Windows
         run: |
-          GOOS=windows GOARCH=amd64 go build -o linear-mcp-go-windows-amd64.exe -v .
+          GOOS=windows GOARCH=amd64 go build -ldflags "-X github.com/geropl/linear-mcp-go/cmd.GitCommit=${{ github.sha }} -X github.com/geropl/linear-mcp-go/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o linear-mcp-go-windows-amd64.exe -v .
 
       - name: Create Release
         id: create_release

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ chmod +x ./linear-mcp-go
 
 ## Usage
 
+### Checking Version
+
+To check the version of the Linear MCP server:
+
+```bash
+./linear-mcp-go version
+```
+
+This will display the version, git commit, and build date information.
+
 ### Running the Server
 
 1. Set your Linear API key as an environment variable:
@@ -219,23 +229,52 @@ Updates all .golden fields.
 
 ## Release Process
 
-The project uses GitHub Actions for automated testing and releases:
+The project uses GitHub Actions for automated testing and releases. The version is managed through the `ServerVersion` constant in `pkg/server/server.go`.
+
+### Automated Testing and Building
 
 1. All pushes to the main branch and pull requests are automatically tested
 2. When a tag matching the pattern `v*` (e.g., `v1.0.0`) is pushed, a new release is automatically created
-3. Binaries for Linux, macOS, and Windows are built and attached to the release
+3. Binaries for Linux, macOS, and Windows are built and attached to the release with build-time information (git commit and build date)
 
-To create a new release:
+### Creating a New Release
 
-1. Update the version in `pkg/server/server.go`
-2. Commit the changes
-3. Create and push a tag matching the version:
-```bash
-git tag v1.0.0
-git push origin v1.0.0
-```
+**Important**: Version tags should only be created against the `main` branch after all changes have been merged.
 
-The GitHub Actions workflow will automatically create a release with the appropriate binaries.
+1. **Update the version**: Modify the `ServerVersion` constant in `pkg/server/server.go`
+   ```go
+   // ServerVersion is the version of the MCP server
+   ServerVersion = "1.13.0"
+   ```
+
+2. **Create a PR**: Submit the version update as a pull request to ensure it goes through review and testing
+
+3. **Merge to main**: Once the PR is approved and merged to the main branch
+
+4. **Create and push the release tag**: 
+   ```bash
+   # Ensure you're on the latest main branch
+   git checkout main
+   git pull origin main
+   
+   # Create and push the tag (must match the version in server.go)
+   git tag v1.13.0
+   git push origin v1.13.0
+   ```
+
+5. **Automated release**: The GitHub Actions workflow will automatically:
+   - Build binaries for all platforms with proper version information
+   - Create a GitHub release with the tag
+   - Attach the compiled binaries to the release
+
+### Version Information
+
+The `version` command displays:
+- **Version**: Read from `ServerVersion` constant in `pkg/server/server.go`
+- **Git commit**: Injected at build time from the current commit hash
+- **Build date**: Injected at build time with the current timestamp
+
+For development builds, git commit and build date will show "unknown".
 
 ## License
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/geropl/linear-mcp-go/pkg/server"
+	"github.com/spf13/cobra"
+)
+
+// Build information - these will be set at build time
+var (
+	GitCommit = "unknown"
+	BuildDate = "unknown"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version information",
+	Long:  `Print the version information for the Linear MCP server.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("Linear MCP Server %s\n", server.ServerVersion)
+		fmt.Printf("Git commit: %s\n", GitCommit)
+		fmt.Printf("Build date: %s\n", BuildDate)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
- Add version command that displays version, git commit, and build date
- Update GitHub Actions workflow to inject version info at build time using ldflags
- Update README.md with documentation for the version command